### PR TITLE
Made the update_scan able to use files with an "rmX_" prefix

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -72,6 +72,8 @@ def scan_updates():
     versions={}
     for f in files:
         p = f.split('_')
+        if(p[0].startswith('rm')):
+            p.pop(0)
         if len(p) != 2:
             continue
         t = p[1].split('.')


### PR DESCRIPTION
I've found a number of update files use this prefix, mainly a convenience tweak